### PR TITLE
Convert tank to arcade drive

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -88,6 +88,9 @@ extern Motor intake;    // convert to pros
 
 extern pros::ADIDigitalOut clampSolenoid;
 
+// arcade drive
+extern std::shared_ptr<ChassisController> drive;
+
 void autonomous(void);
 void initialize(void);
 void disabled(void);

--- a/project.pros
+++ b/project.pros
@@ -1,7 +1,7 @@
 {
   "py/object": "pros.conductor.project.Project",
   "py/state": {
-    "project_name": "285c-stable-arcade",
+    "project_name": "285c-stable",
     "target": "v5",
     "templates": {
       "kernel": {
@@ -312,7 +312,7 @@
       "after": "screen",
       "description": "Backup barebones code for 285C",
       "icon": "clawbot",
-      "slot": 3
+      "slot": 1
     },
     "use_early_access": false
   }

--- a/project.pros
+++ b/project.pros
@@ -1,7 +1,7 @@
 {
   "py/object": "pros.conductor.project.Project",
   "py/state": {
-    "project_name": "285c-stable",
+    "project_name": "285c-stable-arcade",
     "target": "v5",
     "templates": {
       "kernel": {
@@ -312,7 +312,7 @@
       "after": "screen",
       "description": "Backup barebones code for 285C",
       "icon": "clawbot",
-      "slot": 1
+      "slot": 3
     },
     "use_early_access": false
   }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -18,7 +18,7 @@ ControllerButton clampBtn = ControllerDigital::L1;
 
 // ports
 // drive motors
-int8_t driveLFPort = 20;
+int8_t driveLFPort = 18;
 int8_t driveLUPort = 9;
 int8_t driveLBPort = 19;
 int8_t driveRFPort = 11;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -23,7 +23,7 @@ int8_t driveLUPort = 9;
 int8_t driveLBPort = 19;
 int8_t driveRFPort = 11;
 int8_t driveRUPort = 13;
-int8_t driveRBPort = 12;
+int8_t driveRBPort = 14;
 
 // auxiliary motors
 int8_t intakePort = 8;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -56,6 +56,13 @@ MotorGroup driveR({driveRF, driveRU, driveRB});
 
 bool clampState = false; // this is the default state (open)
 
+// arcade drive
+std::shared_ptr<ChassisController> drive = okapi::ChassisControllerBuilder()
+                                               .withMotors(driveL, driveR)
+                                               .withDimensions({AbstractMotor::gearset::blue, (36.0 / 60.0)}, { {3.25_in, 14_in}, imev5BlueTPR })
+                                               .withMaxVelocity(600)
+                                               .build();
+
 void initialize() {
     taskKill();  // kill initialized programs
     intake.setBrakeMode(AbstractMotor::brakeMode::brake);

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -7,6 +7,9 @@ pros::Task buttonInterruptsTask = pros::Task(buttonInterrupts_fn, (void*)"", TAS
 
 void autonomous() {
     taskKill();
+    drive->getModel()->tank(.5, .5);
+    pros::delay(750);
+    drive->getModel()->tank(0, 0);
 }
 
 void opcontrol() {

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -29,8 +29,11 @@ void opcontrol() {
     buttonInterruptsTask.resume();
 
     while (true) { 
-        driveL.moveVoltage((int)(12000 * controller.getAnalog(ControllerAnalog::leftY)));
-        driveR.moveVoltage((int)(12000 * controller.getAnalog(ControllerAnalog::rightY)));
+        // tank drive
+        // driveL.moveVoltage((int)(12000 * controller.getAnalog(ControllerAnalog::leftY)));
+        // driveR.moveVoltage((int)(12000 * controller.getAnalog(ControllerAnalog::rightY)));
+        // arcade drive
+        drive->getModel()->arcade(controller.getAnalog(ControllerAnalog::leftY), controller.getAnalog(ControllerAnalog::rightX));
         pros::delay(20);
     }
 }

--- a/wiring.md
+++ b/wiring.md
@@ -2,7 +2,7 @@
 
 ## Motors
 
-- Left Front Drive  20
+- Left Front Drive  18
 - Left Upper Drive  9
 - Left Back Drive   19
 - Right Front Drive 11

--- a/wiring.md
+++ b/wiring.md
@@ -7,7 +7,7 @@
 - Left Back Drive   19
 - Right Front Drive 11
 - Right Upper Drive 13
-- Right Back Drive  12
+- Right Back Drive  14
 
 - Conveyer          5
 - Intake            8


### PR DESCRIPTION
Using arcade drive now because it's easier to maintain one branch only. Integrates new port assignments and simple auton that drives off the starting line. `drive` object can still be used for tank drive.